### PR TITLE
Added support for inclusion in the Grade Plugin Portal to build.gradle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 CompileOnlyPlugin
 =================
 
-Adds a _compileOnly_ configuration to a Java based gradle build.
+Adds a _compileOnly_ configuration to a Java based Gradle build.
 
 The plugin will also take care of registering the _compilyOnly_ dependencies to the matching scopes of IntelliJ Idea and Eclipse
 
 Usage
 -----
-Add the following lines to your gradle build script
+Add the following lines to your Gradle build script:
 
     buildscript {
       repositories {
@@ -19,6 +19,16 @@ Add the following lines to your gradle build script
     }
 
     apply plugin: 'compileOnly'
+
+    dependencies {
+      compileOnly <dependencies>
+    }
+
+or if using Gradle 2.1 or higher:
+
+    plugins {
+      id 'com.coders-kitchen.compileonlyplugin' version '1.0.0'
+    }
 
     dependencies {
       compileOnly <dependencies>

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,35 @@
 import org.gradle.api.artifacts.maven.MavenDeployment
 
+plugins {
+	id "java-gradle-plugin"
+	id "com.gradle.plugin-publish" version "0.9.4"
+}
+
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
+def mvnName = 'CompileOnlyPlugin'
+def mvnUrl = 'http://coders-kitchen.github.com' // 404, maybe use https://github.com/coders-kitchen/CompileOnlyPlugin instead?
+def mvnDescription = 'Adds a compile only configuration to the Java plugin of Gradle'
+def pluginId = 'com.coders-kitchen.compileonlyplugin'
+
+repositories {
+	jcenter()
+}
 
 dependencies {
 	compile gradleApi()
 	compile localGroovy()
+}
+
+gradlePlugin {
+	plugins {
+		compileOnlyPlugin {
+			id = pluginId
+			implementationClass = "com.coderskitchen.compileonly.CompileOnlyPlugin"
+		}
+	}
 }
 
 task sourcesJar(type: Jar) {
@@ -32,7 +54,8 @@ artifacts {
 	archives sourcesJar
 }
 
-if (hasProperty('sonatypeUsername')) {
+if (hasProperty('sonatypeUsername'))
+{
 	signing {
 		sign configurations.archives
 	}
@@ -47,10 +70,10 @@ if (hasProperty('sonatypeUsername')) {
 				}
 				pom {
 					project {
-						name 'CompileOnlyPlugin'
+						name mvnName
 						packaging 'jar'
-						description 'Adds a compile only configuration to the Java plugin of Gradle'
-						url 'http://coders-kitchen.github.com'
+						description mvnDescription
+						url mvnUrl
 
 						scm {
 							url 'scm:git@github:CodersKitchen/CompileOnlyPlugin.git'
@@ -81,4 +104,16 @@ if (hasProperty('sonatypeUsername')) {
 	}
 }
 
+pluginBundle {
+	website = mvnUrl
+	vcsUrl = 'https://github.com/coders-kitchen/CompileOnlyPlugin'
+	description = mvnDescription
+	tags = ['compile', 'compileOnly', 'java']
 
+	plugins {
+		compileOnlyPlugin {
+			id = pluginId
+			displayName = mvnName
+		}
+	}
+}


### PR DESCRIPTION
See issue #1.

You will need to follow the [submission instructions](https://plugins.gradle.org/docs/submit) to get an an account and API key, then simply run:

``` gradle
gradle publishPlugins
```

I also noticed that the build file is referencing http://coders-kitchen.github.com which returns 404 right now. You might want to change that to https://github.com/coders-kitchen/CompileOnlyPlugin. I've added a comment to the relevant line.

Let me know if you have any questions, problems, etc.
